### PR TITLE
Pass `retrieved_at` to validator.

### DIFF
--- a/lib/turbot_runner/processor.rb
+++ b/lib/turbot_runner/processor.rb
@@ -18,12 +18,9 @@ module TurbotRunner
         else
           record = Openc::JsonSchema.convert_dates(schema_path, JSON.parse(line))
 
-          # TODO Document why we aren't passing retrieved_at to the validator.
-          record_to_validate = record.select {|k, v| k != 'retrieved_at'}
-
           error_message = Validator.validate(
             @data_type,
-            record_to_validate,
+            record,
             @identifying_fields,
             @seen_uids
           )

--- a/spec/lib/processor_spec.rb
+++ b/spec/lib/processor_spec.rb
@@ -126,25 +126,6 @@ describe TurbotRunner::Processor do
         expect(@handler).to receive(:handle_valid_record).with(converted_record, @data_type)
         @processor.process(record.to_json)
       end
-
-      it 'does not pass retrieved_at to validator' do
-        record = {
-          'sample_date' => '2014-06-01',
-          'retrieved_at' => '2014-06-01 12:34:56 +0000',
-          'source_url' => 'http://example.com/123',
-          'number' => 123
-        }
-
-        expected_record_to_validate = {
-          'sample_date' => '2014-06-01',
-          'source_url' => 'http://example.com/123',
-          'number' => 123
-        }
-
-        expect(TurbotRunner::Validator).to receive(:validate).
-          with('primary data', expected_record_to_validate, ['number'], Set.new)
-        @processor.process(record.to_json)
-      end
     end
 
     it 'can handle schemas with $refs' do


### PR DESCRIPTION
Previously we were omitting this. We're not sure why, but it seems
likely it was because simple transformers included a retrieved_at field
which was not validating -- perhaps ones created prior to us extending
json-schema with our own `date` format.

See PR at https://github.com/openc/openc-schema/pull/52 which adds
optional `retrieved_at` to all schemas, and tests simple subsidiaries
are valid.

I've checked every transformer.out I could find on the SAN does validate with respect to `retrieved_at`.
