### PR TITLE
Allow skipping data types in `process_output`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ cache: bundler
 rvm:
   - 1.9.3
   - 2.0.0
-  - 2.1.0
-  - 2.2.0
-  - 2.3.0
+  - 2.1
+  - 2.2
+  - 2.3
 before_install:
   - gem update --system
   - gem update bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,8 @@ rvm:
   - 2.1.0
   - 2.2.0
   - 2.3.0
+before_install:
+  - gem update --system
+  - gem update bundler
 script:
   bundle exec rspec

--- a/lib/turbot_runner/runner.rb
+++ b/lib/turbot_runner/runner.rb
@@ -116,6 +116,8 @@ module TurbotRunner
     end
 
     def process_script_output(script_config, opts)
+      return if opts[:skip_data_types] && opts[:skip_data_types].include?(script_config[:data_type])
+
       # The first argument to the Processor constructor is a nil
       # Runner. This is because no running behaviour
       # (e.g. interruptions etc) is required; we just want to do

--- a/lib/turbot_runner/version.rb
+++ b/lib/turbot_runner/version.rb
@@ -1,3 +1,3 @@
 module TurbotRunner
-  VERSION = '0.2.29'
+  VERSION = '0.2.30'
 end

--- a/spec/lib/runner_spec.rb
+++ b/spec/lib/runner_spec.rb
@@ -348,6 +348,20 @@ describe TurbotRunner::Runner do
 
       runner.process_output
     end
+
+    context 'when skip_data_types is set' do
+      it 'skips the data type' do
+        test_runner('bot-with-transformer').run
+
+        runner = test_runner('bot-with-transformer',
+          :record_handler => @handler
+        )
+
+        runner.process_output(skip_data_types: ['primary data'])
+        expect(@handler.records_seen['primary data']).to eq(0)
+        expect(@handler.records_seen['simple-licence']).to eq(10)
+      end
+    end
   end
 
   describe '#set_up_output_directory' do


### PR DESCRIPTION
Sometimes we want to skip over primary data and only process transformed data. This allows us to do that by specifying an array of data types to skip.