### PR TITLE
Fix ignoring of missing output files

### DIFF
--- a/lib/turbot_runner/runner.rb
+++ b/lib/turbot_runner/runner.rb
@@ -124,15 +124,13 @@ module TurbotRunner
       # record handling.
       processor = Processor.new(nil, script_config, @record_handler)
       file = output_file(script_config[:file])
-      File.open(file) do |f|
-        f.each_line do |line|
-          processor.process(line, opts)
+      if File.exist?(file)
+        File.open(file) do |f|
+          f.each_line do |line|
+            processor.process(line, opts)
+          end
         end
       end
-    rescue Errno::ENOENT => e
-      # We only want to catch ENOENT if the output file doesn't exist, and not
-      # if, for instance, a schema file is missing.
-      raise unless e.message == "No such file or directory - #{output_file(script_config[:file])}"
     end
 
     def build_command(script, input_file=nil)

--- a/spec/lib/runner_spec.rb
+++ b/spec/lib/runner_spec.rb
@@ -385,6 +385,15 @@ describe TurbotRunner::Runner do
         runner.process_output
       end
     end
+
+    context 'when no bot has run' do
+      it 'proceeds without errors' do
+        runner = test_runner('bot-with-transformer',
+          :record_handler => @handler
+        )
+        runner.process_output
+      end
+    end
   end
 
   describe '#set_up_output_directory' do

--- a/spec/lib/runner_spec.rb
+++ b/spec/lib/runner_spec.rb
@@ -315,51 +315,56 @@ describe TurbotRunner::Runner do
       @handler = Handler.new
     end
 
-    it 'calls handler once for each line of output' do
-      test_runner('bot-with-transformer').run
-
-      runner = test_runner('bot-with-transformer',
-        :record_handler => @handler
-      )
-
-      runner.process_output
-      expect(@handler.records_seen['primary data']).to eq(10)
-      expect(@handler.records_seen['simple-licence']).to eq(10)
-    end
-
-    it 'passes opts to processor.process' do
-      test_runner('bot-with-transformer').run
-      runner = test_runner('bot-with-transformer',
-        :record_handler => @handler
-      )
-      opts = {frob: 5}
-      processor = double('processor')
-      allow(TurbotRunner::Processor).to receive(:new).and_return(processor)
-      expect(processor).to receive(:process).with(anything, opts).at_least(:once)
-      runner.process_output(opts)
-    end
-
-    it 'can cope when scraper has failed immediately' do
-      test_runner('bot-that-crashes-immediately').run
-
-      runner = test_runner('bot-that-crashes-immediately',
-        :record_handler => @handler
-      )
-
-      runner.process_output
-    end
-
-    context 'when skip_data_types is set' do
-      it 'skips the data type' do
+    context 'with a bot that runs correctly' do
+      before do
         test_runner('bot-with-transformer').run
+      end
 
+      it 'calls handler once for each line of output' do
         runner = test_runner('bot-with-transformer',
           :record_handler => @handler
         )
 
-        runner.process_output(skip_data_types: ['primary data'])
-        expect(@handler.records_seen['primary data']).to eq(0)
+        runner.process_output
+        expect(@handler.records_seen['primary data']).to eq(10)
         expect(@handler.records_seen['simple-licence']).to eq(10)
+      end
+
+      it 'passes opts to processor.process' do
+        runner = test_runner('bot-with-transformer',
+          :record_handler => @handler
+        )
+        opts = {frob: 5}
+        processor = double('processor')
+        allow(TurbotRunner::Processor).to receive(:new).and_return(processor)
+        expect(processor).to receive(:process).with(anything, opts).at_least(:once)
+        runner.process_output(opts)
+      end
+
+      context 'when skip_data_types is set' do
+        it 'skips the data type' do
+          runner = test_runner('bot-with-transformer',
+            :record_handler => @handler
+          )
+
+          runner.process_output(skip_data_types: ['primary data'])
+          expect(@handler.records_seen['primary data']).to eq(0)
+          expect(@handler.records_seen['simple-licence']).to eq(10)
+        end
+      end
+    end
+
+    context 'with a bot that crashes immediately' do
+      before do
+        test_runner('bot-that-crashes-immediately').run
+      end
+
+      it 'can cope with the empty files' do
+        runner = test_runner('bot-that-crashes-immediately',
+          :record_handler => @handler
+        )
+
+        runner.process_output
       end
     end
   end

--- a/spec/lib/runner_spec.rb
+++ b/spec/lib/runner_spec.rb
@@ -7,6 +7,10 @@ describe TurbotRunner::Runner do
     puts 'If all specs passed, you should now run `ruby spec/manual.rb`'
   end
 
+  after do
+    FileUtils.rm_rf(File.join(@runner.base_directory, "output")) if @runner
+  end
+
   describe '#run' do
     context 'with a bot written in ruby' do
       before do
@@ -329,7 +333,8 @@ describe TurbotRunner::Runner do
 
     context 'with a bot that runs correctly' do
       before do
-        test_runner('bot-with-transformer').run
+        @runner = test_runner('bot-with-transformer')
+        @runner.run
       end
 
       it 'calls handler once for each line of output' do
@@ -368,7 +373,8 @@ describe TurbotRunner::Runner do
 
     context 'with a bot that crashes immediately' do
       before do
-        test_runner('bot-that-crashes-immediately').run
+        @runner = test_runner('bot-that-crashes-immediately')
+        @runner.run
       end
 
       it 'can cope with the empty files' do

--- a/spec/lib/runner_spec.rb
+++ b/spec/lib/runner_spec.rb
@@ -69,11 +69,14 @@ describe TurbotRunner::Runner do
 
     context 'with a bot that logs' do
       context 'when logging to file enabled' do
+        before do
+          @runner = test_runner('logging-bot', :log_to_file => true)
+        end
+
         it 'logs to file' do
           expected_log = "doing...\ndone\n"
-          runner = test_runner('logging-bot', :log_to_file => true)
-          runner.run
-          expect(runner).to have_error_output_matching('scraper', expected_log)
+          @runner.run
+          expect(@runner).to have_error_output_matching('scraper', expected_log)
         end
       end
 
@@ -201,15 +204,21 @@ describe TurbotRunner::Runner do
     end
 
     context 'with a scraper that produces an invalid record' do
-      it 'returns false' do
+      before do
         @runner = test_runner('invalid-record-bot')
+      end
+
+      it 'returns false' do
         expect(@runner).to fail_in_scraper
       end
     end
 
     context 'with a scraper that produces invalid JSON' do
-      it 'returns false' do
+      before do
         @runner = test_runner('invalid-json-bot')
+      end
+
+      it 'returns false' do
         expect(@runner).to fail_in_scraper
       end
     end
@@ -220,11 +229,14 @@ describe TurbotRunner::Runner do
       # output file is created; however, the way we're redirecting
       # stdout using the shell means the file doesn't get created
       # until
-      it 'returns false' do
+      before do
         @runner = test_runner('bot-with-pause',
           :timeout => 1,
           :log_to_file => true
         )
+      end
+
+      it 'returns false' do
         expect(@runner).to fail_in_scraper
       end
     end


### PR DESCRIPTION
Add a test of the 'missing output file' situation (fails running on ruby versions >2.0.0)

Explicitly test File.exists? rather than catching and quashing a 'No such file or directory' exception (Fixes it for versions >2.0.0)

Fixes https://opencorporates.atlassian.net/browse/OCD-1011